### PR TITLE
Fixed  by using numbers instead of floats on total calculation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "backend-challenge",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "start": "ts-node src/index.ts",
-    "build": "tsc",
-    "start:prod": "node dist/index.js"
-  },
-  "author": "",
-  "license": "ISC",
-  "dependencies": {
-    "@fastify/swagger": "^8.14.0",
-    "@fastify/swagger-ui": "^4.0.0",
-    "axios": "^1.7.2",
-    "fastify": "^4.28.1"
-  },
-  "devDependencies": {
-    "@faker-js/faker": "^8.4.1",
-    "@types/node": "^20.14.10",
-    "prettier": "^3.3.2",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.5.3"
-  }
+    "name": "backend-challenge",
+    "version": "1.0.1",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "start": "ts-node src/index.ts",
+        "build": "tsc",
+        "start:prod": "node dist/index.js"
+    },
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "@fastify/swagger": "^8.14.0",
+        "@fastify/swagger-ui": "^4.0.0",
+        "axios": "^1.7.2",
+        "fastify": "^4.28.1"
+    },
+    "devDependencies": {
+        "@faker-js/faker": "^8.4.1",
+        "@types/node": "^20.14.10",
+        "prettier": "^3.3.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.5.3"
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,12 +64,12 @@ server.get('/orders/:id/order-total', async (request, reply) => {
 
     if (order) {
         const total = order.products.reduce(
-            (acc, product) => acc + product.price * product.count,
+            (acc, product) => acc + product.price * 100 * product.count,
             0,
         )
 
         return reply.status(201).send({
-            total,
+            total: total / 100,
         })
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,11 @@ server.get('/orders/:id/order-total', async (request, reply) => {
 
     if (order) {
         const total = order.products.reduce(
-            (acc, product) => acc + product.price * 100 * product.count,
+            (acc, product) =>
+                acc +
+                product.price *
+                    100 /* Don't use float in calculations. */ *
+                    product.count,
             0,
         )
 


### PR DESCRIPTION
This is a well-known problem that you can encounter when working with floats. Especially in interpreted programing languages. JS Math Model is not the only model that you can have this problem with. My preferred method would be never using floats or doubles, not even in DB when dealing with currencies. But for a quick fix this would also serve the purpose. I don't see any where that we do any other calculations similar like we do in `/orders/:id/order-total`